### PR TITLE
Fix dataset search

### DIFF
--- a/apps/network/src/routes/network.py
+++ b/apps/network/src/routes/network.py
@@ -168,7 +168,9 @@ def search_encrypted_model():
         for node in grid_nodes:
             try:
                 response = requests.post(
-                    os.path.join(grid_nodes[node], "/data-centric/search-encrypted-models"),
+                    os.path.join(
+                        grid_nodes[node], "/data-centric/search-encrypted-models"
+                    ),
                     data=request.data,
                 )
             except requests.exceptions.ConnectionError:
@@ -249,7 +251,9 @@ def available_tags():
     tags = set()
     for node in grid_nodes:
         try:
-            response = requests.get(grid_nodes[node] + "/data-centric/dataset-tags").content
+            response = requests.get(
+                grid_nodes[node] + "/data-centric/dataset-tags"
+            ).content
         except requests.exceptions.ConnectionError:
             continue
         response = json.loads(response)
@@ -296,7 +300,7 @@ def search_dataset_tags():
     except Exception as e:
         response_body["message"] = str(e)
         status_code = 500  # Internal Server Error
-    
+
     print("Response body: ", response_body)
     return Response(
         json.dumps(response_body), status=status_code, mimetype="application/json"

--- a/apps/network/src/routes/network.py
+++ b/apps/network/src/routes/network.py
@@ -168,7 +168,7 @@ def search_encrypted_model():
         for node in grid_nodes:
             try:
                 response = requests.post(
-                    os.path.join(grid_nodes[node], "search-encrypted-models"),
+                    os.path.join(grid_nodes[node], "/data-centric/search-encrypted-models"),
                     data=request.data,
                 )
             except requests.exceptions.ConnectionError:
@@ -232,7 +232,7 @@ def available_models():
     models = set()
     for node in grid_nodes:
         try:
-            response = requests.get(grid_nodes[node] + "/models/").content
+            response = requests.get(grid_nodes[node] + "/data-centric/models/").content
         except requests.exceptions.ConnectionError:
             continue
         response = json.loads(response)
@@ -249,7 +249,7 @@ def available_tags():
     tags = set()
     for node in grid_nodes:
         try:
-            response = requests.get(grid_nodes[node] + "/dataset-tags").content
+            response = requests.get(grid_nodes[node] + "/data-centric/dataset-tags").content
         except requests.exceptions.ConnectionError:
             continue
         response = json.loads(response)
@@ -276,7 +276,7 @@ def search_dataset_tags():
         for node in grid_nodes:
             try:
                 response = requests.post(
-                    grid_nodes[node] + "/search",
+                    grid_nodes[node] + "/data-centric/search",
                     data=json.dumps({"query": body["query"]}),
                 ).content
             except requests.exceptions.ConnectionError:
@@ -296,7 +296,8 @@ def search_dataset_tags():
     except Exception as e:
         response_body["message"] = str(e)
         status_code = 500  # Internal Server Error
-
+    
+    print("Response body: ", response_body)
     return Response(
         json.dumps(response_body), status=status_code, mimetype="application/json"
     )
@@ -315,7 +316,7 @@ def _get_model_hosting_nodes(model_id):
     match_nodes = []
     for node in grid_nodes:
         try:
-            response = requests.get(grid_nodes[node] + "/models/").content
+            response = requests.get(grid_nodes[node] + "/data-centric/models/").content
         except requests.exceptions.ConnectionError:
             continue
         response = json.loads(response)

--- a/apps/node/src/__main__.py
+++ b/apps/node/src/__main__.py
@@ -35,7 +35,7 @@ parser.add_argument(
     "--network",
     type=str,
     help="Grid Network address, e.g. --network=0.0.0.0:5000. Default is os.environ.get('NETWORK',None).",
-    default=os.environ.get("NETWORK",None),
+    default=os.environ.get("NETWORK", None),
 )
 
 parser.add_argument(
@@ -76,11 +76,10 @@ if __name__ == "__main__":
     _address = "http://{}:{}".format(args.host, args.port)
     if _address and _network:
         requests.post(
-                os.path.join(_network, "join"),
-                data=json.dumps(
-                    {"node-id": args.id,
-                     "node-address": "{}".format(_address)}
-                    ),
+            os.path.join(_network, "join"),
+            data=json.dumps(
+                {"node-id": args.id, "node-address": "{}".format(_address)}
+            ),
         )
 
     server = pywsgi.WSGIServer(
@@ -94,11 +93,10 @@ else:
     _network = os.environ.get("NETWORK", None)
     if _address and _network:
         requests.post(
-                os.path.join(_network, "join"),
-                data=json.dumps(
-                    {"node-id": node_id,
-                     "node-address": "{}".format(_address)}
-                ),
+            os.path.join(_network, "join"),
+            data=json.dumps(
+                {"node-id": node_id, "node-address": "{}".format(_address)}
+            ),
         )
 
     app = create_app(node_id=node_id, debug=False, n_replica=num_replicas)

--- a/apps/node/src/__main__.py
+++ b/apps/node/src/__main__.py
@@ -6,6 +6,8 @@ and route grid workers remotely."""
 import argparse
 import os
 import sys
+import json
+import requests
 
 from gevent import pywsgi
 from geventwebsocket.handler import WebSocketHandler
@@ -27,6 +29,13 @@ parser.add_argument(
     type=str,
     help="Grid node host, e.g. --host=0.0.0.0. Default is os.environ.get('GRID_HOST','0.0.0.0').",
     default=os.environ.get("GRID_HOST", "0.0.0.0"),
+)
+
+parser.add_argument(
+    "--network",
+    type=str,
+    help="Grid Network address, e.g. --network=0.0.0.0:5000. Default is os.environ.get('NETWORK',None).",
+    default=os.environ.get("NETWORK",None),
 )
 
 parser.add_argument(
@@ -63,6 +72,17 @@ if __name__ == "__main__":
     else:
         app = create_app(node_id=args.id, debug=False, n_replica=args.num_replicas)
 
+    _network = args.network
+    _address = "http://{}:{}".format(args.host, args.port)
+    if _address and _network:
+        requests.post(
+                os.path.join(_network, "join"),
+                data=json.dumps(
+                    {"node-id": args.id,
+                     "node-address": "{}".format(_address)}
+                    ),
+        )
+
     server = pywsgi.WSGIServer(
         (args.host, args.port), app, handler_class=WebSocketHandler
     )
@@ -70,4 +90,15 @@ if __name__ == "__main__":
 else:
     node_id = os.environ.get("NODE_ID", None)
     num_replicas = os.environ.get("N_REPLICAS", None)
+    _address = os.environ.get("ADDRESS", None)
+    _network = os.environ.get("NETWORK", None)
+    if _address and _network:
+        requests.post(
+                os.path.join(_network, "join"),
+                data=json.dumps(
+                    {"node-id": node_id,
+                     "node-address": "{}".format(_address)}
+                ),
+        )
+
     app = create_app(node_id=node_id, debug=False, n_replica=num_replicas)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - NODE_ID=Bob
       - ADDRESS=http://bob:3000/
       - PORT=3000
+      - NETWORK=http://network:5000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'
@@ -28,6 +29,7 @@ services:
       - NODE_ID=Alice
       - ADDRESS=http://alice:3001/
       - PORT=3001
+      - NETWORK=http://network:5000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'
@@ -40,6 +42,7 @@ services:
       - NODE_ID=Bill
       - ADDRESS=http://bill:3002/
       - PORT=3002
+      - NETWORK=http://network:5000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'
@@ -52,6 +55,7 @@ services:
       - NODE_ID=James
       - ADDRESS=http://james:3003/
       - PORT=3003
+      - NETWORK=http://network:5000
       - DATABASE_URL=sqlite:///databasenode.db
     depends_on:
       - 'network'


### PR DESCRIPTION
## Description
- During the [model-centric/data-centric rename PR](https://github.com/OpenMined/PyGrid/commit/928f732ecf082544433f69c41cb6817005fdcd0a) the network endpoints were not updated. So the network app was trying to reach the `/search` node endpoint (which is now` /data-centric/search`).
- The missing argument during network node initialization. So the nodes were not registering their addresses in the desired network.


## How has this been tested?
- Build docker images (node/network)
- Register datasets using ModelCentricFLClient
- Search for the datasets using the PublicGridNetwork class


## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented on my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests